### PR TITLE
Add state class support to current sensors

### DIFF
--- a/components/dsmr/sensor.py
+++ b/components/dsmr/sensor.py
@@ -2,17 +2,19 @@ import esphome.codegen as cg
 import esphome.config_validation as cv
 from esphome.components import sensor
 from esphome.const import (
+    DEVICE_CLASS_CURRENT,
+    DEVICE_CLASS_EMPTY,
+    DEVICE_CLASS_ENERGY,
+    DEVICE_CLASS_POWER,
+    DEVICE_CLASS_VOLTAGE,
     ICON_EMPTY,
+    STATE_CLASS_NONE,
+    STATE_CLASS_MEASUREMENT,
+    UNIT_AMPERE,
     UNIT_EMPTY,
     UNIT_VOLT,
-    UNIT_WATT,
-    UNIT_AMPERE,
     UNIT_WATT_HOURS,
-    DEVICE_CLASS_EMPTY,
-    DEVICE_CLASS_POWER,
-    DEVICE_CLASS_ENERGY,
-    DEVICE_CLASS_CURRENT,
-    DEVICE_CLASS_VOLTAGE,
+    UNIT_WATT,
 )
 from . import DSMR, CONF_DSMR_ID
 
@@ -23,130 +25,130 @@ CONFIG_SCHEMA = cv.Schema(
     {
         cv.GenerateID(CONF_DSMR_ID): cv.use_id(DSMR),
         cv.Optional("energy_delivered_lux"): sensor.sensor_schema(
-            "kWh", ICON_EMPTY, 3, DEVICE_CLASS_ENERGY
+            "kWh", ICON_EMPTY, 3, DEVICE_CLASS_ENERGY, STATE_CLASS_NONE
         ),
         cv.Optional("energy_delivered_tariff1"): sensor.sensor_schema(
-            "kWh", ICON_EMPTY, 3, DEVICE_CLASS_ENERGY
+            "kWh", ICON_EMPTY, 3, DEVICE_CLASS_ENERGY, STATE_CLASS_NONE
         ),
         cv.Optional("energy_delivered_tariff2"): sensor.sensor_schema(
-            "kWh", ICON_EMPTY, 3, DEVICE_CLASS_ENERGY
+            "kWh", ICON_EMPTY, 3, DEVICE_CLASS_ENERGY, STATE_CLASS_NONE
         ),
         cv.Optional("energy_returned_lux"): sensor.sensor_schema(
-            "kWh", ICON_EMPTY, 3, DEVICE_CLASS_ENERGY
+            "kWh", ICON_EMPTY, 3, DEVICE_CLASS_ENERGY, STATE_CLASS_NONE
         ),
         cv.Optional("energy_returned_tariff1"): sensor.sensor_schema(
-            "kWh", ICON_EMPTY, 3, DEVICE_CLASS_ENERGY
+            "kWh", ICON_EMPTY, 3, DEVICE_CLASS_ENERGY, STATE_CLASS_NONE
         ),
         cv.Optional("energy_returned_tariff2"): sensor.sensor_schema(
-            "kWh", ICON_EMPTY, 3, DEVICE_CLASS_ENERGY
+            "kWh", ICON_EMPTY, 3, DEVICE_CLASS_ENERGY, STATE_CLASS_NONE
         ),
         cv.Optional("total_imported_energy"): sensor.sensor_schema(
-            "kvarh", ICON_EMPTY, 3, DEVICE_CLASS_ENERGY
+            "kvarh", ICON_EMPTY, 3, DEVICE_CLASS_ENERGY, STATE_CLASS_NONE
         ),
         cv.Optional("total_exported_energy"): sensor.sensor_schema(
-            "kvarh", ICON_EMPTY, 3, DEVICE_CLASS_ENERGY
+            "kvarh", ICON_EMPTY, 3, DEVICE_CLASS_ENERGY, STATE_CLASS_NONE
         ),
         cv.Optional("power_delivered"): sensor.sensor_schema(
-            UNIT_WATT, ICON_EMPTY, 3, DEVICE_CLASS_POWER
+            UNIT_WATT, ICON_EMPTY, 3, DEVICE_CLASS_POWER, STATE_CLASS_MEASUREMENT
         ),
         cv.Optional("power_returned"): sensor.sensor_schema(
-            UNIT_WATT, ICON_EMPTY, 3, DEVICE_CLASS_POWER
+            UNIT_WATT, ICON_EMPTY, 3, DEVICE_CLASS_POWER, STATE_CLASS_MEASUREMENT
         ),
         cv.Optional("reactive_power_delivered"): sensor.sensor_schema(
-            "kvar", ICON_EMPTY, 3, DEVICE_CLASS_ENERGY
+            "kvar", ICON_EMPTY, 3, DEVICE_CLASS_ENERGY, STATE_CLASS_NONE
         ),
         cv.Optional("reactive_power_returned"): sensor.sensor_schema(
-            "kvar", ICON_EMPTY, 3, DEVICE_CLASS_ENERGY
+            "kvar", ICON_EMPTY, 3, DEVICE_CLASS_ENERGY, STATE_CLASS_MEASUREMENT
         ),
         cv.Optional("electricity_threshold"): sensor.sensor_schema(
-            UNIT_EMPTY, ICON_EMPTY, 3, DEVICE_CLASS_EMPTY
+            UNIT_EMPTY, ICON_EMPTY, 3, DEVICE_CLASS_EMPTY, STATE_CLASS_NONE
         ),
         cv.Optional("electricity_switch_position"): sensor.sensor_schema(
-            UNIT_EMPTY, ICON_EMPTY, 3, DEVICE_CLASS_EMPTY
+            UNIT_EMPTY, ICON_EMPTY, 3, DEVICE_CLASS_EMPTY, STATE_CLASS_NONE
         ),
         cv.Optional("electricity_failures"): sensor.sensor_schema(
-            UNIT_EMPTY, ICON_EMPTY, 0, DEVICE_CLASS_EMPTY
+            UNIT_EMPTY, ICON_EMPTY, 0, DEVICE_CLASS_EMPTY, STATE_CLASS_NONE
         ),
         cv.Optional("electricity_long_failures"): sensor.sensor_schema(
-            UNIT_EMPTY, ICON_EMPTY, 0, DEVICE_CLASS_EMPTY
+            UNIT_EMPTY, ICON_EMPTY, 0, DEVICE_CLASS_EMPTY, STATE_CLASS_NONE
         ),
         cv.Optional("electricity_sags_l1"): sensor.sensor_schema(
-            UNIT_EMPTY, ICON_EMPTY, 0, DEVICE_CLASS_EMPTY
+            UNIT_EMPTY, ICON_EMPTY, 0, DEVICE_CLASS_EMPTY, STATE_CLASS_NONE
         ),
         cv.Optional("electricity_sags_l2"): sensor.sensor_schema(
-            UNIT_EMPTY, ICON_EMPTY, 0, DEVICE_CLASS_EMPTY
+            UNIT_EMPTY, ICON_EMPTY, 0, DEVICE_CLASS_EMPTY, STATE_CLASS_MEASUREMENT
         ),
         cv.Optional("electricity_sags_l3"): sensor.sensor_schema(
-            UNIT_EMPTY, ICON_EMPTY, 0, DEVICE_CLASS_EMPTY
+            UNIT_EMPTY, ICON_EMPTY, 0, DEVICE_CLASS_EMPTY, STATE_CLASS_NONE
         ),
         cv.Optional("electricity_swells_l1"): sensor.sensor_schema(
-            UNIT_EMPTY, ICON_EMPTY, 0, DEVICE_CLASS_EMPTY
+            UNIT_EMPTY, ICON_EMPTY, 0, DEVICE_CLASS_EMPTY, STATE_CLASS_MEASUREMENT
         ),
         cv.Optional("electricity_swells_l2"): sensor.sensor_schema(
-            UNIT_EMPTY, ICON_EMPTY, 0, DEVICE_CLASS_EMPTY
+            UNIT_EMPTY, ICON_EMPTY, 0, DEVICE_CLASS_EMPTY, STATE_CLASS_NONE
         ),
         cv.Optional("electricity_swells_l3"): sensor.sensor_schema(
-            UNIT_EMPTY, ICON_EMPTY, 0, DEVICE_CLASS_EMPTY
+            UNIT_EMPTY, ICON_EMPTY, 0, DEVICE_CLASS_EMPTY, STATE_CLASS_NONE
         ),
         cv.Optional("current_l1"): sensor.sensor_schema(
-            UNIT_AMPERE, ICON_EMPTY, 1, DEVICE_CLASS_CURRENT
+            UNIT_AMPERE, ICON_EMPTY, 1, DEVICE_CLASS_CURRENT, STATE_CLASS_MEASUREMENT
         ),
         cv.Optional("current_l2"): sensor.sensor_schema(
-            UNIT_AMPERE, ICON_EMPTY, 1, DEVICE_CLASS_CURRENT
+            UNIT_AMPERE, ICON_EMPTY, 1, DEVICE_CLASS_CURRENT, STATE_CLASS_MEASUREMENT
         ),
         cv.Optional("current_l3"): sensor.sensor_schema(
-            UNIT_AMPERE, ICON_EMPTY, 1, DEVICE_CLASS_CURRENT
+            UNIT_AMPERE, ICON_EMPTY, 1, DEVICE_CLASS_CURRENT, STATE_CLASS_MEASUREMENT
         ),
         cv.Optional("power_delivered_l1"): sensor.sensor_schema(
-            UNIT_WATT, ICON_EMPTY, 3, DEVICE_CLASS_POWER
+            UNIT_WATT, ICON_EMPTY, 3, DEVICE_CLASS_POWER, STATE_CLASS_MEASUREMENT
         ),
         cv.Optional("power_delivered_l2"): sensor.sensor_schema(
-            UNIT_WATT, ICON_EMPTY, 3, DEVICE_CLASS_POWER
+            UNIT_WATT, ICON_EMPTY, 3, DEVICE_CLASS_POWER, STATE_CLASS_MEASUREMENT
         ),
         cv.Optional("power_delivered_l3"): sensor.sensor_schema(
-            UNIT_WATT, ICON_EMPTY, 3, DEVICE_CLASS_POWER
+            UNIT_WATT, ICON_EMPTY, 3, DEVICE_CLASS_POWER, STATE_CLASS_MEASUREMENT
         ),
         cv.Optional("power_returned_l1"): sensor.sensor_schema(
-            UNIT_WATT, ICON_EMPTY, 3, DEVICE_CLASS_POWER
+            UNIT_WATT, ICON_EMPTY, 3, DEVICE_CLASS_POWER, STATE_CLASS_MEASUREMENT
         ),
         cv.Optional("power_returned_l2"): sensor.sensor_schema(
-            UNIT_WATT, ICON_EMPTY, 3, DEVICE_CLASS_POWER
+            UNIT_WATT, ICON_EMPTY, 3, DEVICE_CLASS_POWER, STATE_CLASS_MEASUREMENT
         ),
         cv.Optional("power_returned_l3"): sensor.sensor_schema(
-            UNIT_WATT, ICON_EMPTY, 3, DEVICE_CLASS_POWER
+            UNIT_WATT, ICON_EMPTY, 3, DEVICE_CLASS_POWER, STATE_CLASS_MEASUREMENT
         ),
         cv.Optional("reactive_power_delivered_l1"): sensor.sensor_schema(
-            UNIT_WATT, ICON_EMPTY, 3, DEVICE_CLASS_POWER
+            UNIT_WATT, ICON_EMPTY, 3, DEVICE_CLASS_POWER, STATE_CLASS_MEASUREMENT
         ),
         cv.Optional("reactive_power_delivered_l2"): sensor.sensor_schema(
-            UNIT_WATT, ICON_EMPTY, 3, DEVICE_CLASS_POWER
+            UNIT_WATT, ICON_EMPTY, 3, DEVICE_CLASS_POWER, STATE_CLASS_MEASUREMENT
         ),
         cv.Optional("reactive_power_delivered_l3"): sensor.sensor_schema(
-            UNIT_WATT, ICON_EMPTY, 3, DEVICE_CLASS_POWER
+            UNIT_WATT, ICON_EMPTY, 3, DEVICE_CLASS_POWER, STATE_CLASS_MEASUREMENT
         ),
         cv.Optional("reactive_power_returned_l1"): sensor.sensor_schema(
-            UNIT_WATT, ICON_EMPTY, 3, DEVICE_CLASS_POWER
+            UNIT_WATT, ICON_EMPTY, 3, DEVICE_CLASS_POWER, STATE_CLASS_MEASUREMENT
         ),
         cv.Optional("reactive_power_returned_l2"): sensor.sensor_schema(
-            UNIT_WATT, ICON_EMPTY, 3, DEVICE_CLASS_POWER
+            UNIT_WATT, ICON_EMPTY, 3, DEVICE_CLASS_POWER, STATE_CLASS_MEASUREMENT
         ),
         cv.Optional("reactive_power_returned_l3"): sensor.sensor_schema(
-            UNIT_WATT, ICON_EMPTY, 3, DEVICE_CLASS_POWER
+            UNIT_WATT, ICON_EMPTY, 3, DEVICE_CLASS_POWER, STATE_CLASS_MEASUREMENT
         ),
         cv.Optional("voltage_l1"): sensor.sensor_schema(
-            UNIT_VOLT, ICON_EMPTY, 1, DEVICE_CLASS_VOLTAGE
+            UNIT_VOLT, ICON_EMPTY, 1, DEVICE_CLASS_VOLTAGE, STATE_CLASS_NONE
         ),
         cv.Optional("voltage_l2"): sensor.sensor_schema(
-            UNIT_VOLT, ICON_EMPTY, 1, DEVICE_CLASS_VOLTAGE
+            UNIT_VOLT, ICON_EMPTY, 1, DEVICE_CLASS_VOLTAGE, STATE_CLASS_NONE
         ),
         cv.Optional("voltage_l3"): sensor.sensor_schema(
-            UNIT_VOLT, ICON_EMPTY, 1, DEVICE_CLASS_VOLTAGE
+            UNIT_VOLT, ICON_EMPTY, 1, DEVICE_CLASS_VOLTAGE, STATE_CLASS_NONE
         ),
         cv.Optional("gas_delivered"): sensor.sensor_schema(
-            "m³", ICON_EMPTY, 3, DEVICE_CLASS_EMPTY
+            "m³", ICON_EMPTY, 3, DEVICE_CLASS_EMPTY, STATE_CLASS_NONE
         ),
         cv.Optional("gas_delivered_be"): sensor.sensor_schema(
-            "m³", ICON_EMPTY, 3, DEVICE_CLASS_EMPTY
+            "m³", ICON_EMPTY, 3, DEVICE_CLASS_EMPTY, STATE_CLASS_NONE
         ),
     }
 ).extend(cv.COMPONENT_SCHEMA)


### PR DESCRIPTION
This PR adds support for the state class attributes of the sensors provided by the DSMR component.
It provides a hint to Home Assistant on these measurements begin current values, so Home Assistant can collect long-term data with those.

This requires ESPHome 1.19.0 or newer to build.