### PR TITLE
Add support state classes to summing sensors

### DIFF
--- a/components/dsmr/sensor.py
+++ b/components/dsmr/sensor.py
@@ -8,8 +8,9 @@ from esphome.const import (
     DEVICE_CLASS_POWER,
     DEVICE_CLASS_VOLTAGE,
     ICON_EMPTY,
-    STATE_CLASS_NONE,
+    LAST_RESET_TYPE_NEVER,
     STATE_CLASS_MEASUREMENT,
+    STATE_CLASS_NONE,
     UNIT_AMPERE,
     UNIT_EMPTY,
     UNIT_VOLT,
@@ -25,22 +26,52 @@ CONFIG_SCHEMA = cv.Schema(
     {
         cv.GenerateID(CONF_DSMR_ID): cv.use_id(DSMR),
         cv.Optional("energy_delivered_lux"): sensor.sensor_schema(
-            "kWh", ICON_EMPTY, 3, DEVICE_CLASS_ENERGY, STATE_CLASS_NONE
+            "kWh",
+            ICON_EMPTY,
+            3,
+            DEVICE_CLASS_ENERGY,
+            STATE_CLASS_MEASUREMENT,
+            LAST_RESET_TYPE_NEVER,
         ),
         cv.Optional("energy_delivered_tariff1"): sensor.sensor_schema(
-            "kWh", ICON_EMPTY, 3, DEVICE_CLASS_ENERGY, STATE_CLASS_NONE
+            "kWh",
+            ICON_EMPTY,
+            3,
+            DEVICE_CLASS_ENERGY,
+            STATE_CLASS_MEASUREMENT,
+            LAST_RESET_TYPE_NEVER
         ),
         cv.Optional("energy_delivered_tariff2"): sensor.sensor_schema(
-            "kWh", ICON_EMPTY, 3, DEVICE_CLASS_ENERGY, STATE_CLASS_NONE
+            "kWh",
+            ICON_EMPTY,
+            3,
+            DEVICE_CLASS_ENERGY,
+            STATE_CLASS_MEASUREMENT,
+            LAST_RESET_TYPE_NEVER,
         ),
         cv.Optional("energy_returned_lux"): sensor.sensor_schema(
-            "kWh", ICON_EMPTY, 3, DEVICE_CLASS_ENERGY, STATE_CLASS_NONE
+            "kWh",
+            ICON_EMPTY,
+            3,
+            DEVICE_CLASS_ENERGY,
+            STATE_CLASS_MEASUREMENT,
+            LAST_RESET_TYPE_NEVER,
         ),
         cv.Optional("energy_returned_tariff1"): sensor.sensor_schema(
-            "kWh", ICON_EMPTY, 3, DEVICE_CLASS_ENERGY, STATE_CLASS_NONE
+            "kWh",
+            ICON_EMPTY,
+            3,
+            DEVICE_CLASS_ENERGY,
+            STATE_CLASS_MEASUREMENT,
+            LAST_RESET_TYPE_NEVER,
         ),
         cv.Optional("energy_returned_tariff2"): sensor.sensor_schema(
-            "kWh", ICON_EMPTY, 3, DEVICE_CLASS_ENERGY, STATE_CLASS_NONE
+            "kWh",
+            ICON_EMPTY,
+            3,
+            DEVICE_CLASS_ENERGY,
+            STATE_CLASS_MEASUREMENT,
+            LAST_RESET_TYPE_NEVER,
         ),
         cv.Optional("total_imported_energy"): sensor.sensor_schema(
             "kvarh", ICON_EMPTY, 3, DEVICE_CLASS_ENERGY, STATE_CLASS_NONE
@@ -145,10 +176,20 @@ CONFIG_SCHEMA = cv.Schema(
             UNIT_VOLT, ICON_EMPTY, 1, DEVICE_CLASS_VOLTAGE, STATE_CLASS_NONE
         ),
         cv.Optional("gas_delivered"): sensor.sensor_schema(
-            "m³", ICON_EMPTY, 3, DEVICE_CLASS_EMPTY, STATE_CLASS_NONE
+            "m³",
+            ICON_EMPTY,
+            3,
+            DEVICE_CLASS_EMPTY,
+            STATE_CLASS_MEASUREMENT,
+            LAST_RESET_TYPE_NEVER,
         ),
         cv.Optional("gas_delivered_be"): sensor.sensor_schema(
-            "m³", ICON_EMPTY, 3, DEVICE_CLASS_EMPTY, STATE_CLASS_NONE
+            "m³",
+            ICON_EMPTY,
+            3,
+            DEVICE_CLASS_EMPTY,
+            STATE_CLASS_MEASUREMENT,
+            LAST_RESET_TYPE_NEVER
         ),
     }
 ).extend(cv.COMPONENT_SCHEMA)


### PR DESCRIPTION
This adds support for state classes to sensors that show a summed value.

The `state_class` is set to `measurement` and the `last_reset` is set to `never` (which results in epoch)

![image](https://user-images.githubusercontent.com/195327/127403711-8b511fc4-9421-4b13-8f62-c8fe577a0433.png)

This works with the new energy and statistics features shipped with the upcoming Home Assistant Core 2021.8.0 (and is backward compatible for Home Assistant).

It does require at least ESPHome 1.20.0
