### PR TITLE
Update for Home Assistant 2021.9

### DIFF
--- a/slimmelezer.yaml
+++ b/slimmelezer.yaml
@@ -86,16 +86,22 @@ sensor:
   - platform: dsmr
     energy_delivered_lux:
       name: "Energy Consumed Luxembourg"
+      state_class: "total_increasing"
     energy_delivered_tariff1:
       name: "Energy Consumed Tariff 1"
+      state_class: "total_increasing"
     energy_delivered_tariff2:
       name: "Energy Consumed Tariff 2"
+      state_class: "total_increasing"
     energy_returned_lux:
       name: "Energy Produced Luxembourg"
+      state_class: "total_increasing"
     energy_returned_tariff1:
       name: "Energy Produced Tariff 1"
+      state_class: "total_increasing"
     energy_returned_tariff2:
       name: "Energy Produced Tariff 2"
+      state_class: "total_increasing"
     power_delivered:
       name: "Power Consumed"
       accuracy_decimals: 0
@@ -156,8 +162,10 @@ sensor:
         - multiply: 1000
     gas_delivered:
       name: "Gas Consumed"
+      state_class: "total_increasing"
     gas_delivered_be:
       name: "Gas Consumed Belgium"
+      state_class: "total_increasing"
   - platform: uptime
     name: "Uptime"
   - platform: wifi_signal


### PR DESCRIPTION
Home Assistant 2021.9 changed the long term statistics: https://developers.home-assistant.io/docs/core/entity/sensor/#long-term-statistics

This PR fixes the following error if you upgrade to Home Assistant 2021.9.x

<img width="374" alt="Screenshot 2021-09-03 at 10 00 26" src="https://user-images.githubusercontent.com/80709/131972254-25258bdf-3a36-46ff-bc54-97c844a43952.png">
