### PR TITLE
Disable serial logging to enable hardware UART

### DIFF
--- a/slimmelezer.yaml
+++ b/slimmelezer.yaml
@@ -40,6 +40,7 @@ captive_portal:
 
 # Enable logging
 logger:
+  baud_rate: 0
 
 # Enable Home Assistant API
 api:


### PR DESCRIPTION
ESPHome 2021.9.0 has a new check in UART that switches the serial to use SoftwareSerial if the serial logger is enabled and the uart is using the swap pins (RX: GPIO13) 