### PR TITLE
Update slimmelezer.yaml

### DIFF
--- a/slimmelezer.yaml
+++ b/slimmelezer.yaml
@@ -106,13 +106,9 @@ sensor:
     power_delivered:
       name: "Power Consumed"
       accuracy_decimals: 0
-      filters:
-        - multiply: 1000
     power_returned:
       name: "Power Produced"
       accuracy_decimals: 0
-      filters:
-        - multiply: 1000
     electricity_failures:
       name: "Electricity Failures"
       icon: mdi:alert
@@ -134,33 +130,21 @@ sensor:
     power_delivered_l1:
       name: "Power Consumed Phase 1"
       accuracy_decimals: 0
-      filters:
-        - multiply: 1000
     power_delivered_l2:
       name: "Power Consumed Phase 2"
       accuracy_decimals: 0
-      filters:
-        - multiply: 1000
     power_delivered_l3:
       name: "Power Consumed Phase 3"
       accuracy_decimals: 0
-      filters:
-        - multiply: 1000
     power_returned_l1:
       name: "Power Produced Phase 1"
       accuracy_decimals: 0
-      filters:
-        - multiply: 1000
     power_returned_l2:
       name: "Power Produced Phase 2"
       accuracy_decimals: 0
-      filters:
-        - multiply: 1000
     power_returned_l3:
       name: "Power Produced Phase 3"
       accuracy_decimals: 0
-      filters:
-        - multiply: 1000
     gas_delivered:
       name: "Gas Consumed"
       state_class: "total_increasing"


### PR DESCRIPTION
ESPHome 2021.9.0 is now using kW instead of W as unit of measurment. Multiplying is not longer necessary and will produce outputs that is 1000 times higher than actual usage.