### PR TITLE
Increase RX buffer size

### DIFF
--- a/slimmelezer.yaml
+++ b/slimmelezer.yaml
@@ -69,6 +69,7 @@ web_server:
 uart:
   baud_rate: 115200
   rx_pin: D7
+  rx_buffer_size: 1500
  
 globals:
   - id: has_key


### PR DESCRIPTION
With the DSMR issues in ESPHome 2021.10.1 it was recommended to increase the `rx_buffer_size` e.g. https://github.com/esphome/issues/issues/2621 and https://github.com/esphome/issues/issues/2577

The numbers mentioned vary from 1000 to 1500. I went with the 1500 and that has been running fine for almost a month now, so suggesting to use that value.