### PR TITLE
Update slimmelezer.yaml to fix OTA breaking change of ESPHome 2024.6.0

### DIFF
--- a/slimmelezer.yaml
+++ b/slimmelezer.yaml
@@ -59,6 +59,7 @@ api:
           id(dsmr_instance).set_decryption_key(private_key);
 
 ota:
+  platform: esphome
 
 dashboard_import:
   package_import_url: github://zuidwijk/dsmr/slimmelezer.yaml@main


### PR DESCRIPTION
Include necessary platform key for ota as per the breaking change of ESPHome 2024.6.0 https://github.com/esphome/esphome/pull/6459.