### PR TITLE
Fixes compile error on ESPHome 2026.03

### DIFF
--- a/slimmelezer.yaml
+++ b/slimmelezer.yaml
@@ -60,7 +60,7 @@ api:
           value: !lambda "return private_key.length() == 32;"
       - lambda: |-
           if (private_key.length() == 32)
-            private_key.copy(id(stored_decryption_key), 32);
+            memcpy(id(stored_decryption_key), private_key.c_str(), 32);
           id(dsmr_instance).set_decryption_key(private_key.c_str());
 
 ota:


### PR DESCRIPTION
The new ESPHome version 2026.03 gives a compile error for the YAML:

```
Compiling .pioenvs/slimmelezer/src/main.cpp.o
/config/esphome/slimmelezer.yaml: In lambda function: /config/esphome/slimmelezer.yaml:69:21: error: 'class esphome::StringRef' has no member named 'copy'
   69 |             private_key.copy(id(stored_decryption_key), 32);
      |                     ^~~~
*** [.pioenvs/slimmelezer/src/main.cpp.o] Error 1
```

In ESPHome 2026.03, the type of string values passed into lambdas changed from `std::string` to `esphome::StringRef`. StringRef doesn't have the `.copy()` method that `std::string` has. The proposed implementation uses `memcpy` and `.c_str()` which is available in `StringRef`. 