### PR TITLE
Add Belgian peak demand registers (1-0:1.4.0 / 1-0:1.6.0) to slimmelezer-be.yaml

### DIFF
--- a/slimmelezer-be.yaml
+++ b/slimmelezer-be.yaml
@@ -121,6 +121,12 @@ sensor:
       unit_of_measurement: "m³"
       id: gas_delivered_belgium
       state_class: total_increasing
+    active_energy_import_current_average_demand:
+      name: "Current Average Demand"
+    active_energy_import_maximum_demand_running_month:
+      name: "Maximum Demand Running Month"
+    active_energy_import_maximum_demand_last_13_months:
+      name: "Maximum Demand Last 13 Months"
   - platform: uptime
     name: "SlimmeLezer Uptime"
   - platform: wifi_signal


### PR DESCRIPTION
Hi Marcel,

(Issues are disabled on this repo, so proposing this directly as a PR.)

First off - thanks for the SlimmeLezer. I've only had it running on my Fluvius meter for a week, but it's been flawless so far.

**What this adds:** since the introduction of the *capaciteitstarief* in Flanders, the quarter-hour peak is the number every Belgian user cares about. The meter computes and publishes these registers on P1, and ESPHome's `dsmr` component already supports them - this PR exposes them in `slimmelezer-be.yaml`:

- `active_energy_import_current_average_demand` - the meter's live quarter-hour average (OBIS 1-0:1.4.0)
- `active_energy_import_maximum_demand_running_month` - the official running-month maximum that Fluvius bills on (1-0:1.6.0)
- `active_energy_import_maximum_demand_last_13_months` - 13-month history (0-0:98.1.0)

No template math or `utility_meter` workarounds needed on the HA side, and immune to Wi-Fi gaps.

**Tested** on a SlimmeLezer (ESP8266 d1_mini, firmware 2.0) against a Fluvius S211 (`FLU5\...`), compiled with ESPHome 2026.4.1: all three report correctly (cross-checked the month peak against a manually computed value - matched within rounding), and existing entity IDs are untouched.

These OBIS codes are Belgium-only (NL meters don't emit them), which is why this targets `slimmelezer-be.yaml`.
